### PR TITLE
added 'pod-security.kubernetes.io/enforce: privileged' to namespace l…

### DIFF
--- a/pkg/detective/setup.go
+++ b/pkg/detective/setup.go
@@ -20,6 +20,10 @@ func (d *Detective) createNamespace() error {
 	spec := &core.Namespace{
 		ObjectMeta: meta.ObjectMeta{
 			GenerateName: "detective-",
+			Labels: map[string]string{
+				"pod-security.kubernetes.io/enforce":         "privileged",
+				"pod-security.kubernetes.io/enforce-version": "latest",
+			},
 		},
 		Status: core.NamespaceStatus{},
 	}


### PR DESCRIPTION
Namespace label 'pod-security.kubernetes.io/enforce: privileged' allows running this test on k8s 1.26+. Default PodSecurity Admission Controller policy pod-security.kubernetes.io/enforce: baseline blocks HostNetwork and fails kube-detective running.